### PR TITLE
fix(CI): Changing the API keys to uppercase

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -32,13 +32,12 @@ jobs:
         uses: pullfrog/action@main
         env: 
           log_level: ${{ vars.LOG_LEVEL }}
-        with:
-          prompt: ${{ github.event.inputs.prompt }}
-
           # feel free to comment out any you won't use
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        with:
+          prompt: ${{ github.event.inputs.prompt }}
           


### PR DESCRIPTION
Fixes https://github.com/pullfrog/pullfrog/issues/63 — partially, for this repo only, not for the app yet

Due to c335032
See diff https://github.com/pullfrog/action/commit/c335032c37b5aa957ee3d9f7d37a937ed3ece150#diff-35ec9ad6938f4a0788911257499ca3ccf99c80cca56a22e86706f2c17f636835