### PR TITLE
fix runNpx: avoid devEngines check on workspace; resolve npx via node

### DIFF
--- a/runCli.ts
+++ b/runCli.ts
@@ -38,13 +38,37 @@ function createRuntimeContext(): RuntimeContext {
   };
 }
 
-function runNpx(context: RuntimeContext, packageSpec: string, cliArgs: string[]): void {
-  const npxPath =
+function resolveNpxCommand(context: RuntimeContext): { command: string; prefixArgs: string[] } {
+  // Prefer invoking npm's npx-cli.js directly via the current node executable. This avoids
+  // ENOENT when the npx shim is not on PATH or alongside the node binary, and guarantees we
+  // use the same node runtime that's executing this script.
+  const npxCliCandidates = [
+    // Unix: <prefix>/bin/node + <prefix>/lib/node_modules/npm/bin/npx-cli.js
+    join(context.nodeBinDir, "..", "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+    // Windows: <prefix>/node.exe + <prefix>/node_modules/npm/bin/npx-cli.js
+    join(context.nodeBinDir, "node_modules", "npm", "bin", "npx-cli.js"),
+  ];
+  for (const candidate of npxCliCandidates) {
+    if (existsSync(candidate)) {
+      return { command: process.execPath, prefixArgs: [candidate] };
+    }
+  }
+
+  // Fall back to the npx shim alongside node.
+  const npxShim =
     process.platform === "win32"
       ? join(context.nodeBinDir, "npx.cmd")
       : join(context.nodeBinDir, "npx");
-  execFileSync(npxPath, ["--yes", packageSpec, ...cliArgs], {
-    cwd: process.env.GITHUB_WORKSPACE || context.actionRoot,
+  return { command: npxShim, prefixArgs: [] };
+}
+
+function runNpx(context: RuntimeContext, packageSpec: string, cliArgs: string[]): void {
+  const { command, prefixArgs } = resolveNpxCommand(context);
+  // Run from actionRoot rather than GITHUB_WORKSPACE so that npm's devEngines check (which
+  // reads cwd's package.json) doesn't reject the install when the workspace's package.json
+  // pins a non-npm package manager. The pullfrog CLI itself reads GITHUB_WORKSPACE from env.
+  execFileSync(command, [...prefixArgs, "--yes", packageSpec, ...cliArgs], {
+    cwd: context.actionRoot,
     stdio: "inherit",
     env: context.env,
   });


### PR DESCRIPTION
Fixes two failure modes in `runNpx()` (runCli.ts):

### 1. `EBADDEVENGINES` when the workspace pins a non-npm package manager

`runNpx` was launching with `cwd = GITHUB_WORKSPACE || actionRoot`. npm's `devEngines.packageManager` check reads the cwd's `package.json` during install — so if the user's repo declares e.g. `devEngines.packageManager: { name: "pnpm" }`, npm aborts the install with `EBADDEVENGINES`.

Switched cwd to `actionRoot` (which is what `runLocalCli` already does). The action's own `package.json` doesn't set `devEngines`, and the pullfrog CLI reads the workspace path from `GITHUB_WORKSPACE` env, not from cwd — see `utils/payload.ts:60`.

### 2. `ENOENT` when the npx shim isn't alongside the node binary

Previously we always called `<nodeBinDir>/npx[.cmd]`. In setups where node is invoked from a path that doesn't have the npx shim alongside it, this throws ENOENT.

Added `resolveNpxCommand` which prefers invoking `npm/bin/npx-cli.js` directly via `process.execPath` (the same node that's running this script), checking the standard Unix layout (`<prefix>/lib/node_modules/npm/bin/npx-cli.js`) and Windows layout (`<prefix>/node_modules/npm/bin/npx-cli.js`). Falls back to the original shim if neither is found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the action resolves and executes `npx` (including cwd and command path), which could affect CLI installation/execution across environments.
> 
> **Overview**
> Fixes `runNpx` execution in `runCli.ts` by running installs from the action directory (avoiding npm `devEngines`/`packageManager` checks triggered by the repo workspace `package.json`).
> 
> Adds `resolveNpxCommand` to prefer invoking npm’s `npx-cli.js` via the current `node` executable (with Unix/Windows candidate paths), falling back to the `npx`/`npx.cmd` shim when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa8ef7d49b6f273a4f0e94c9dafbf0c5eca9257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->