### PR TITLE
Add managed auth writeback plumbing

### DIFF
--- a/agents/opencode.ts
+++ b/agents/opencode.ts
@@ -27,7 +27,11 @@ import {
 } from "../utils/activity.ts";
 import { type AgentDiagnostic, formatAgentHangBody } from "../utils/agentHangReport.ts";
 import { formatJsonValue, log } from "../utils/cli.ts";
-import { installCodexAuth } from "../utils/codexHome.ts";
+import { applyManagedAuthEnv, installManagedAuth } from "../utils/managedAuth.ts";
+import {
+  MANAGED_AUTH_WRITEBACK_STATE,
+  stringifyManagedAuthWritebacks,
+} from "../utils/managedAuthState.ts";
 import { findProviderErrorMatch } from "../utils/providerErrors.ts";
 import { addSkill, installBundledSkills } from "../utils/skills.ts";
 import {
@@ -1186,12 +1190,9 @@ export const opencode = agent({
 
     installBundledSkills({ home: homeEnv.HOME });
 
-    // materialize CODEX_AUTH_JSON (Pullfrog-stored Codex subscription
-    // credential) into the runner's REAL $HOME/.local/share/opencode/auth.json
-    // so OpenCode's CodexAuthPlugin picks it up and routes openai requests
-    // through the ChatGPT subscription instead of needing OPENAI_API_KEY.
-    // see action/utils/codexHome.ts and wiki/codex-auth.md.
-    const codexAuth = installCodexAuth();
+    // materialize managed credentials (Codex today, other model auth shapes
+    // later) into agent-readable locations before OpenCode starts.
+    const managedAuth = installManagedAuth({ apiToken: ctx.apiToken });
 
     // base args shared between initial run and continue runs
     const baseArgs = ["run", "--format", "json", "--print-logs"];
@@ -1230,25 +1231,16 @@ export const opencode = agent({
         process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.GEMINI_API_KEY,
     };
 
-    if (codexAuth) {
-      // point OpenCode at the real-home XDG dir so it reads auth.json from
-      // where we wrote it (not the tmpdir-redirected default).
-      env.XDG_DATA_HOME = codexAuth.xdgDataHome;
-      // remove OPENAI_API_KEY so OpenCode's provider merge unambiguously
-      // picks the OAuth path. with both set, the merge order in opencode
-      // makes the effective key ambiguous.
-      delete env.OPENAI_API_KEY;
-      // hand the post-hook everything it needs to detect + persist refresh.
-      // post-hook runs in a fresh node process, so we have to ferry apiToken
-      // explicitly — env is preserved across main/post but our run-context
-      // JWT is computed at runtime and not put in env. see action/entryPost.ts.
+    applyManagedAuthEnv(env, managedAuth.env);
+
+    if (managedAuth.writebacks.length > 0) {
+      // hand the post-hook everything it needs to detect + persist refreshes.
+      // post-hook runs in a fresh node process, so we ferry apiToken
+      // explicitly — env is preserved across main/post but our run-context JWT
+      // is computed at runtime and not put in env. see action/entryPost.ts.
       core.saveState(
-        "codex_writeback",
-        JSON.stringify({
-          apiToken: ctx.apiToken,
-          authPath: codexAuth.authPath,
-          originalRefresh: codexAuth.originalRefresh,
-        })
+        MANAGED_AUTH_WRITEBACK_STATE,
+        stringifyManagedAuthWritebacks(managedAuth.writebacks)
       );
     }
 

--- a/entryPost.stdlibOnly.test.ts
+++ b/entryPost.stdlibOnly.test.ts
@@ -89,6 +89,7 @@ describe("entryPost.ts stdlib-only invariant (#834)", () => {
     expect(direct).toEqual([
       "./utils/codexRefreshDetect.ts",
       "./utils/ghaCore.ts",
+      "./utils/managedAuthState.ts",
       "./utils/postApiFetch.ts",
       "node:fs",
     ]);

--- a/entryPost.ts
+++ b/entryPost.ts
@@ -14,11 +14,11 @@
 // silently goes stale on the first refresh and the next run fails. See
 // wiki/codex-auth.md.
 //
-// Today's only job: detect a Codex auth refresh by diffing the on-disk
-// auth.json against the original refresh token (saved to GH Actions state
-// by action/agents/opencode_v2.ts — see also the legacy v1 file kept as
-// reference at action/agents/opencode.ts), convert OpenCode's auth shape
-// back to Codex CLI shape, and PUT it to /api/runtime/secret.
+// Today's managed-auth job: detect refreshes for any installed managed
+// credential and write the rotated secret back to Pullfrog. Codex is the
+// first provider: diff the on-disk auth.json against the original refresh
+// token, convert OpenCode's auth shape back to Codex CLI shape, and PUT it
+// to /api/runtime/secret.
 //
 // Silent no-op when the main step didn't materialize Codex auth (no state
 // saved). Best-effort: failures are logged but never throw — the workflow
@@ -31,43 +31,95 @@
 import { existsSync, readFileSync } from "node:fs";
 import { detectCodexRefresh } from "./utils/codexRefreshDetect.ts";
 import * as core from "./utils/ghaCore.ts";
+import {
+  MANAGED_AUTH_WRITEBACK_STATE,
+  type ManagedAuthWriteback,
+  parseManagedAuthWritebacks,
+} from "./utils/managedAuthState.ts";
 import { postApiFetch } from "./utils/postApiFetch.ts";
 
 async function main(): Promise<void> {
-  const raw = core.getState("codex_writeback");
-  if (!raw) {
-    core.info("codex post-hook: no writeback state — skipping");
+  const writebacks = readWritebackState();
+  if (writebacks.length === 0) {
+    core.info("managed-auth post-hook: no writeback state — skipping");
     return;
   }
 
-  let state: { apiToken: string; authPath: string; originalRefresh: string };
+  for (const writeback of writebacks) {
+    await handleWriteback(writeback);
+  }
+}
+
+function readWritebackState(): ManagedAuthWriteback[] {
+  const raw = core.getState(MANAGED_AUTH_WRITEBACK_STATE);
+  if (raw) {
+    const writebacks = parseManagedAuthWritebacks(raw);
+    if (!writebacks) {
+      core.warning("managed-auth post-hook: malformed writeback state — skipping");
+      return [];
+    }
+    return writebacks;
+  }
+
+  const legacy = core.getState("codex_writeback");
+  if (!legacy) return [];
+
+  let state: { apiToken?: unknown; authPath?: unknown; originalRefresh?: unknown };
   try {
-    state = JSON.parse(raw) as typeof state;
+    state = JSON.parse(legacy) as typeof state;
   } catch (err) {
-    core.warning(`codex post-hook: malformed writeback state — ${err}`);
-    return;
-  }
-  if (!state.apiToken || !state.authPath || !state.originalRefresh) {
-    core.warning("codex post-hook: incomplete writeback state — skipping");
-    return;
+    core.warning(`codex post-hook: malformed legacy writeback state — ${err}`);
+    return [];
   }
 
-  if (!existsSync(state.authPath)) {
-    core.info(`codex post-hook: ${state.authPath} not found — nothing to write back`);
+  if (
+    typeof state.apiToken !== "string" ||
+    typeof state.authPath !== "string" ||
+    typeof state.originalRefresh !== "string" ||
+    state.apiToken.length === 0 ||
+    state.authPath.length === 0 ||
+    state.originalRefresh.length === 0
+  ) {
+    core.warning("codex post-hook: incomplete legacy writeback state — skipping");
+    return [];
+  }
+
+  return [
+    {
+      kind: "codex",
+      apiToken: state.apiToken,
+      secretName: "CODEX_AUTH_JSON",
+      authPath: state.authPath,
+      originalRefresh: state.originalRefresh,
+    },
+  ];
+}
+
+async function handleWriteback(writeback: ManagedAuthWriteback): Promise<void> {
+  switch (writeback.kind) {
+    case "codex":
+      await handleCodexWriteback(writeback);
+      return;
+  }
+}
+
+async function handleCodexWriteback(writeback: Extract<ManagedAuthWriteback, { kind: "codex" }>) {
+  if (!existsSync(writeback.authPath)) {
+    core.info(`codex post-hook: ${writeback.authPath} not found — nothing to write back`);
     return;
   }
 
   let authFileContent: string;
   try {
-    authFileContent = readFileSync(state.authPath, "utf8");
+    authFileContent = readFileSync(writeback.authPath, "utf8");
   } catch (err) {
-    core.warning(`codex post-hook: cannot read ${state.authPath} — ${err}`);
+    core.warning(`codex post-hook: cannot read ${writeback.authPath} — ${err}`);
     return;
   }
 
   const refreshedCodexJson = detectCodexRefresh({
     authFileContent,
-    originalRefresh: state.originalRefresh,
+    originalRefresh: writeback.originalRefresh,
   });
   if (!refreshedCodexJson) {
     core.info("codex post-hook: refresh chain unchanged — no writeback needed");
@@ -79,10 +131,10 @@ async function main(): Promise<void> {
       path: "/api/runtime/secret",
       method: "PUT",
       headers: {
-        authorization: `Bearer ${state.apiToken}`,
+        authorization: `Bearer ${writeback.apiToken}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({ name: "CODEX_AUTH_JSON", value: refreshedCodexJson }),
+      body: JSON.stringify({ name: writeback.secretName, value: refreshedCodexJson }),
     });
     if (!response.ok) {
       const body = await response.text().catch(() => "");

--- a/main.ts
+++ b/main.ts
@@ -20,7 +20,6 @@ import { validateAgentApiKey } from "./utils/apiKeys.ts";
 import { resolveBody } from "./utils/body.ts";
 import { selectFallbackModelIfNeeded } from "./utils/byokFallback.ts";
 import { log } from "./utils/cli.ts";
-import { installCodexAuth, PULLFROG_DATA_DIR } from "./utils/codexHome.ts";
 import { recordDiffReadFromToolUse } from "./utils/diffCoverage.ts";
 import { onExitSignal } from "./utils/exitHandler.ts";
 import { resolveGit, setGitAuthServer } from "./utils/gitAuth.ts";
@@ -29,6 +28,7 @@ import { createOctokit, writeGitHubUsageSummaryToFile } from "./utils/github.ts"
 import { resolveInstructions } from "./utils/instructions.ts";
 import { persistLearnings, seedLearningsFile } from "./utils/learnings.ts";
 import { describeSetupFailure, executeLifecycleHook } from "./utils/lifecycle.ts";
+import { applyManagedAuthEnv, installManagedAuth } from "./utils/managedAuth.ts";
 import { normalizeEnv, sanitizeSecret } from "./utils/normalizeEnv.ts";
 import {
   captureAuthorizedModels,
@@ -156,11 +156,11 @@ export async function main(): Promise<MainResult> {
     if (count > 0) log.info(`» ${count} db secret(s) loaded`);
   }
 
-  // materialize Codex auth.json (idempotent — opencode agent re-calls inside
-  // run() and writes the same file). this has to land BEFORE
-  // captureAuthorizedModels so OpenCode's model introspection sees the
-  // OAuth-routed openai/* models.
-  installCodexAuth();
+  // materialize managed credentials (Codex today, other model auth shapes
+  // later). this has to land BEFORE captureAuthorizedModels so OpenCode's
+  // model introspection sees OAuth-routed models.
+  const managedAuth = installManagedAuth();
+  applyManagedAuthEnv(process.env, managedAuth.env);
 
   // capture the AUTHORIZED model set after dbSecrets + Codex auth.json are
   // applied. this is the authoritative source for the BYOK fallback
@@ -568,12 +568,13 @@ export async function main(): Promise<MainResult> {
       resolvedModel,
       mcpServerUrl: mcpHttpServer.url,
       tmpdir,
-      // PULLFROG_DATA_DIR (/var/lib/pullfrog) holds codex auth.json + any
-      // future pullfrog-managed on-disk secrets. bash via MCP tmpfs-overlays
-      // it; agent native FS tools deny it via the same secretDenyPaths plumbing
-      // used for vertex creds. see wiki/security.md "Filesystem Sandbox".
+      // managedAuth.secretDenyPaths holds Pullfrog-managed on-disk secrets
+      // (Codex auth.json today, future provider auth files later). bash via
+      // MCP tmpfs-overlays those paths; agent native FS tools deny them via
+      // the same plumbing used for vertex creds. see wiki/security.md
+      // "Filesystem Sandbox".
       secretDenyPaths: [
-        PULLFROG_DATA_DIR,
+        ...managedAuth.secretDenyPaths,
         ...(vertexCredentials ? [vertexCredentials.secretDir] : []),
       ],
       instructions,

--- a/utils/managedAuth.ts
+++ b/utils/managedAuth.ts
@@ -1,0 +1,60 @@
+import { installCodexAuth, PULLFROG_DATA_DIR } from "./codexHome.ts";
+import type { ManagedAuthWriteback } from "./managedAuthState.ts";
+
+export interface ManagedAuthInstall {
+  /** Env changes to apply to processes that need managed auth. `undefined` deletes a var. */
+  env: Record<string, string | undefined>;
+  /** Filesystem paths that native agent tools and MCP shell must not expose. */
+  secretDenyPaths: string[];
+  /** Post-hook persistence records for refreshable managed credentials. */
+  writebacks: ManagedAuthWriteback[];
+}
+
+interface InstallManagedAuthParams {
+  /** Present when the caller wants refresh write-back state for the post hook. */
+  apiToken?: string | undefined;
+}
+
+export function installManagedAuth(params: InstallManagedAuthParams = {}): ManagedAuthInstall {
+  const env: Record<string, string | undefined> = {};
+  const writebacks: ManagedAuthWriteback[] = [];
+
+  const codexAuth = installCodexAuth();
+  if (codexAuth) {
+    env.XDG_DATA_HOME = codexAuth.xdgDataHome;
+    // OpenCode's provider merge can otherwise ambiguously prefer the API-key
+    // path over Codex OAuth. Keep subscription auth deterministic.
+    env.OPENAI_API_KEY = undefined;
+
+    if (params.apiToken) {
+      writebacks.push({
+        kind: "codex",
+        apiToken: params.apiToken,
+        secretName: "CODEX_AUTH_JSON",
+        authPath: codexAuth.authPath,
+        originalRefresh: codexAuth.originalRefresh,
+      });
+    }
+  }
+
+  return {
+    env,
+    // /var/lib/pullfrog is the reserved home for Pullfrog-managed on-disk
+    // secrets. It remains denied even when no credential is installed.
+    secretDenyPaths: [PULLFROG_DATA_DIR],
+    writebacks,
+  };
+}
+
+export function applyManagedAuthEnv(
+  env: Record<string, string | undefined>,
+  changes: Record<string, string | undefined>
+): void {
+  for (const [key, value] of Object.entries(changes)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+}

--- a/utils/managedAuthState.test.ts
+++ b/utils/managedAuthState.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  MANAGED_AUTH_WRITEBACK_STATE,
+  parseManagedAuthWritebacks,
+  stringifyManagedAuthWritebacks,
+  type ManagedAuthWriteback,
+} from "./managedAuthState.ts";
+
+describe("managed auth writeback state", () => {
+  const codex: ManagedAuthWriteback = {
+    kind: "codex",
+    apiToken: "pullfrog-runtime-token",
+    secretName: "CODEX_AUTH_JSON",
+    authPath: "/var/lib/pullfrog/opencode/auth.json",
+    originalRefresh: "rt_original",
+  };
+
+  it("uses a stable GitHub Actions state key", () => {
+    expect(MANAGED_AUTH_WRITEBACK_STATE).toBe("managed_auth_writebacks");
+  });
+
+  it("round-trips codex writeback records", () => {
+    const raw = stringifyManagedAuthWritebacks([codex]);
+
+    expect(parseManagedAuthWritebacks(raw)).toEqual([codex]);
+  });
+
+  it("accepts an empty list", () => {
+    expect(parseManagedAuthWritebacks("[]")).toEqual([]);
+  });
+
+  it("rejects malformed JSON", () => {
+    expect(parseManagedAuthWritebacks("{not-json")).toBeNull();
+  });
+
+  it("rejects non-list state", () => {
+    expect(parseManagedAuthWritebacks(JSON.stringify(codex))).toBeNull();
+  });
+
+  it("rejects unsupported provider records", () => {
+    expect(parseManagedAuthWritebacks(JSON.stringify([{ kind: "some-future-provider" }]))).toBeNull();
+  });
+
+  it("rejects incomplete codex records", () => {
+    expect(
+      parseManagedAuthWritebacks(
+        JSON.stringify([{ ...codex, originalRefresh: "", authPath: "/tmp/auth.json" }])
+      )
+    ).toBeNull();
+  });
+
+  it("rejects codex records pointed at a different secret", () => {
+    expect(
+      parseManagedAuthWritebacks(JSON.stringify([{ ...codex, secretName: "OPENAI_API_KEY" }]))
+    ).toBeNull();
+  });
+});

--- a/utils/managedAuthState.ts
+++ b/utils/managedAuthState.ts
@@ -1,0 +1,56 @@
+export const MANAGED_AUTH_WRITEBACK_STATE = "managed_auth_writebacks";
+
+export interface CodexManagedAuthWriteback {
+  kind: "codex";
+  apiToken: string;
+  secretName: "CODEX_AUTH_JSON";
+  authPath: string;
+  originalRefresh: string;
+}
+
+export type ManagedAuthWriteback = CodexManagedAuthWriteback;
+
+export function stringifyManagedAuthWritebacks(writebacks: ManagedAuthWriteback[]): string {
+  return JSON.stringify(writebacks);
+}
+
+export function parseManagedAuthWritebacks(raw: string): ManagedAuthWriteback[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) return null;
+
+  const writebacks: ManagedAuthWriteback[] = [];
+  for (const item of parsed) {
+    const writeback = parseManagedAuthWriteback(item);
+    if (!writeback) return null;
+    writebacks.push(writeback);
+  }
+
+  return writebacks;
+}
+
+function parseManagedAuthWriteback(value: unknown): ManagedAuthWriteback | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+
+  if (v.kind === "codex") {
+    if (typeof v.apiToken !== "string" || v.apiToken.length === 0) return null;
+    if (v.secretName !== "CODEX_AUTH_JSON") return null;
+    if (typeof v.authPath !== "string" || v.authPath.length === 0) return null;
+    if (typeof v.originalRefresh !== "string" || v.originalRefresh.length === 0) return null;
+    return {
+      kind: "codex",
+      apiToken: v.apiToken,
+      secretName: "CODEX_AUTH_JSON",
+      authPath: v.authPath,
+      originalRefresh: v.originalRefresh,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add a provider-neutral managed auth writeback state shape
- Wrap the existing Codex auth materialization behind managed auth runtime plumbing
- Update the post hook to process managed auth writebacks while preserving legacy codex_writeback fallback

## Verification
- pnpm vitest run entryPost.stdlibOnly.test.ts utils/managedAuthState.test.ts utils/codexRefreshDetect.test.ts
- pnpm typecheck
- pnpm build
- pnpm run check:entrypoints
- pnpm vitest run --exclude test/ci.test.ts

Note: pnpm test -- --run still fails in this standalone checkout because test/ci.test.ts expects ../.github/workflows/test.yml outside the cloned repo directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how subscription credentials are materialized, env is shaped, and rotated secrets are persisted after runs, though behavior for Codex should match prior logic with added validation and legacy state fallback.
> 
> **Overview**
> Introduces **managed auth** as a shared runtime layer around today’s Codex materialization: `installManagedAuth` returns env tweaks, filesystem deny paths, and optional post-hook **writeback** records; callers apply those via `applyManagedAuthEnv` instead of inlining `installCodexAuth` / `XDG_DATA_HOME` / `OPENAI_API_KEY` handling.
> 
> The GHA post step now reads **`managed_auth_writebacks`** (a validated list of `{ kind: "codex", ... }` records) and processes each writeback, while still accepting the old **`codex_writeback`** state as a one-record fallback. OpenCode and `main` save the new state key when an API token is available for refresh persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6912abd8299f9735bb978997533bb395e457035f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->