### PR TITLE
Add Qwen provider (OpenAI-compatible BYOK)

### DIFF
--- a/agents/opencode.ts
+++ b/agents/opencode.ts
@@ -94,6 +94,13 @@ const installCli = () => installOpencodeCli({ binPath: "bin/opencode" });
 // on merge in session/llm.ts), so the env var is the only working knob.
 
 function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
+  const qwenApiKey =
+    process.env.QWEN_API_KEY ?? process.env.DASHSCOPE_API_KEY ?? process.env.LLM_API_KEY;
+  const qwenBaseUrl =
+    process.env.QWEN_BASE_URL ??
+    process.env.DASHSCOPE_BASE_URL ??
+    process.env.LLM_BASE_URL ??
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
   const config: OpenCodeConfig = {
     permission: {
       bash: "deny",
@@ -133,7 +140,22 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
     // tools, so we lose only the batch wrapper, not parallelism.
     // gemini-3 thinking pinned to high for review depth; gpt and anthropic
     // effort set elsewhere (gpt: upstream default, anthropic: --effort flag in claude.ts).
-    provider: { google: { models: geminiHighThinkingOverrides() } },
+    provider: {
+      google: { models: geminiHighThinkingOverrides() },
+      qwen: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Qwen",
+        options: {
+          baseURL: qwenBaseUrl,
+          ...(qwenApiKey ? { apiKey: qwenApiKey } : {}),
+        },
+        models: {
+          "qwen3-coder-plus": { name: "Qwen3 Coder Plus" },
+          "qwen-plus": { name: "Qwen Plus" },
+          "qwen-max": { name: "Qwen Max" },
+        },
+      },
+    },
   };
 
   if (model) {

--- a/agents/opencode.ts
+++ b/agents/opencode.ts
@@ -47,6 +47,7 @@ import {
   autoSelectModel,
   buildReviewerAgentConfig,
   geminiHighThinkingOverrides,
+  qwenProviderConfig,
   installOpencodeCli,
   type OpenCodeConfig,
 } from "./opencodeShared.ts";
@@ -94,13 +95,6 @@ const installCli = () => installOpencodeCli({ binPath: "bin/opencode" });
 // on merge in session/llm.ts), so the env var is the only working knob.
 
 function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
-  const qwenApiKey =
-    process.env.QWEN_API_KEY ?? process.env.DASHSCOPE_API_KEY ?? process.env.LLM_API_KEY;
-  const qwenBaseUrl =
-    process.env.QWEN_BASE_URL ??
-    process.env.DASHSCOPE_BASE_URL ??
-    process.env.LLM_BASE_URL ??
-    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
   const config: OpenCodeConfig = {
     permission: {
       bash: "deny",
@@ -142,19 +136,7 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
     // effort set elsewhere (gpt: upstream default, anthropic: --effort flag in claude.ts).
     provider: {
       google: { models: geminiHighThinkingOverrides() },
-      qwen: {
-        npm: "@ai-sdk/openai-compatible",
-        name: "Qwen",
-        options: {
-          baseURL: qwenBaseUrl,
-          ...(qwenApiKey ? { apiKey: qwenApiKey } : {}),
-        },
-        models: {
-          "qwen3-coder-plus": { name: "Qwen3 Coder Plus" },
-          "qwen-plus": { name: "Qwen Plus" },
-          "qwen-max": { name: "Qwen Max" },
-        },
-      },
+      qwen: qwenProviderConfig(),
     },
   };
 

--- a/agents/opencodeShared.ts
+++ b/agents/opencodeShared.ts
@@ -44,11 +44,8 @@ export function geminiHighThinkingOverrides(): Record<string, { options: object 
 }
 
 /**
- * OpenAI-compatible Qwen provider, materialized into the action-owned
- * OPENCODE_CONFIG_CONTENT. The models map is derived from the qwen aliases in
- * models.ts so a `resolve` bump (e.g. via models-bump) flows through without an
- * edit here. Key/baseURL come from QWEN_* → DASHSCOPE_* → LLM_* (LLM_* as a
- * generic OpenAI-compatible fallback), defaulting to the DashScope intl URL.
+ * OpenAI-compatible Qwen provider for OPENCODE_CONFIG_CONTENT. Models derive from
+ * the qwen aliases in models.ts; key/baseURL from QWEN_* → DASHSCOPE_* → LLM_*.
  */
 export function qwenProviderConfig(): Record<string, unknown> {
   const apiKey =

--- a/agents/opencodeShared.ts
+++ b/agents/opencodeShared.ts
@@ -44,6 +44,34 @@ export function geminiHighThinkingOverrides(): Record<string, { options: object 
 }
 
 /**
+ * OpenAI-compatible Qwen provider, materialized into the action-owned
+ * OPENCODE_CONFIG_CONTENT. The models map is derived from the qwen aliases in
+ * models.ts so a `resolve` bump (e.g. via models-bump) flows through without an
+ * edit here. Key/baseURL come from QWEN_* → DASHSCOPE_* → LLM_* (LLM_* as a
+ * generic OpenAI-compatible fallback), defaulting to the DashScope intl URL.
+ */
+export function qwenProviderConfig(): Record<string, unknown> {
+  const apiKey =
+    process.env.QWEN_API_KEY ?? process.env.DASHSCOPE_API_KEY ?? process.env.LLM_API_KEY;
+  const baseURL =
+    process.env.QWEN_BASE_URL ??
+    process.env.DASHSCOPE_BASE_URL ??
+    process.env.LLM_BASE_URL ??
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+  const models = Object.fromEntries(
+    modelAliases
+      .filter((a) => a.provider === "qwen")
+      .map((a) => [a.resolve.replace(/^qwen\//, ""), { name: a.displayName }])
+  );
+  return {
+    npm: "@ai-sdk/openai-compatible",
+    name: "Qwen",
+    options: { baseURL, ...(apiKey ? { apiKey } : {}) },
+    models,
+  };
+}
+
+/**
  * Read-only `reviewfrog` subagent for lens-based review. Non-mutative +
  * non-recursive — enforced by the system prompt in reviewer.ts.
  *

--- a/agents/opencode_v2.ts
+++ b/agents/opencode_v2.ts
@@ -104,6 +104,13 @@ const installCli = () => installOpencodeCli({ binPath: "bin/opencode.exe" });
 // ── config ─────────────────────────────────────────────────────────────────────
 
 function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
+  const qwenApiKey =
+    process.env.QWEN_API_KEY ?? process.env.DASHSCOPE_API_KEY ?? process.env.LLM_API_KEY;
+  const qwenBaseUrl =
+    process.env.QWEN_BASE_URL ??
+    process.env.DASHSCOPE_BASE_URL ??
+    process.env.LLM_BASE_URL ??
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
   const config: OpenCodeConfig = {
     permission: {
       bash: "deny",
@@ -130,7 +137,22 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
     })(),
     // gemini-3 thinking pinned to high for review depth; gpt and anthropic
     // effort set elsewhere (gpt: upstream default, anthropic: --effort flag in claude.ts).
-    provider: { google: { models: geminiHighThinkingOverrides() } },
+    provider: {
+      google: { models: geminiHighThinkingOverrides() },
+      qwen: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Qwen",
+        options: {
+          baseURL: qwenBaseUrl,
+          ...(qwenApiKey ? { apiKey: qwenApiKey } : {}),
+        },
+        models: {
+          "qwen3-coder-plus": { name: "Qwen3 Coder Plus" },
+          "qwen-plus": { name: "Qwen Plus" },
+          "qwen-max": { name: "Qwen Max" },
+        },
+      },
+    },
   };
 
   if (model) {

--- a/agents/opencode_v2.ts
+++ b/agents/opencode_v2.ts
@@ -79,6 +79,7 @@ import {
   autoSelectModel,
   buildReviewerAgentConfig,
   geminiHighThinkingOverrides,
+  qwenProviderConfig,
   installOpencodeCli,
   type OpenCodeConfig,
 } from "./opencodeShared.ts";
@@ -104,13 +105,6 @@ const installCli = () => installOpencodeCli({ binPath: "bin/opencode.exe" });
 // ── config ─────────────────────────────────────────────────────────────────────
 
 function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
-  const qwenApiKey =
-    process.env.QWEN_API_KEY ?? process.env.DASHSCOPE_API_KEY ?? process.env.LLM_API_KEY;
-  const qwenBaseUrl =
-    process.env.QWEN_BASE_URL ??
-    process.env.DASHSCOPE_BASE_URL ??
-    process.env.LLM_BASE_URL ??
-    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
   const config: OpenCodeConfig = {
     permission: {
       bash: "deny",
@@ -139,19 +133,7 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
     // effort set elsewhere (gpt: upstream default, anthropic: --effort flag in claude.ts).
     provider: {
       google: { models: geminiHighThinkingOverrides() },
-      qwen: {
-        npm: "@ai-sdk/openai-compatible",
-        name: "Qwen",
-        options: {
-          baseURL: qwenBaseUrl,
-          ...(qwenApiKey ? { apiKey: qwenApiKey } : {}),
-        },
-        models: {
-          "qwen3-coder-plus": { name: "Qwen3 Coder Plus" },
-          "qwen-plus": { name: "Qwen Plus" },
-          "qwen-max": { name: "Qwen Max" },
-        },
-      },
+      qwen: qwenProviderConfig(),
     },
   };
 

--- a/models.test.ts
+++ b/models.test.ts
@@ -52,6 +52,14 @@ describe("getModelEnvVars", () => {
     expect(envVars).toContain("GEMINI_API_KEY");
   });
 
+  it("returns correct env vars for qwen", () => {
+    expect(getModelEnvVars("qwen/qwen-coder")).toEqual([
+      "QWEN_API_KEY",
+      "DASHSCOPE_API_KEY",
+      "LLM_API_KEY",
+    ]);
+  });
+
   it("returns empty array for unknown provider", () => {
     expect(getModelEnvVars("unknown/model")).toEqual([]);
   });
@@ -78,6 +86,11 @@ describe("resolveModelSlug", () => {
   it("resolves openai alias", () => {
     const resolved = resolveModelSlug("openai/gpt");
     expect(resolved).toBe("openai/gpt-5.5");
+  });
+
+  it("resolves qwen alias", () => {
+    const resolved = resolveModelSlug("qwen/qwen-coder");
+    expect(resolved).toBe("qwen/qwen3-coder-plus");
   });
 
   it("returns the raw resolve for deprecated aliases (does not walk fallback)", () => {

--- a/models.ts
+++ b/models.ts
@@ -281,6 +281,9 @@ export const providers = {
   }),
   qwen: provider({
     displayName: "Qwen",
+    // checked in precedence order. LLM_API_KEY is a deliberately generic
+    // OpenAI-compatible fallback (last), so a dedicated QWEN_API_KEY /
+    // DASHSCOPE_API_KEY always wins over it.
     envVars: ["QWEN_API_KEY", "DASHSCOPE_API_KEY", "LLM_API_KEY"],
     models: {
       "qwen-coder": {

--- a/models.ts
+++ b/models.ts
@@ -273,6 +273,28 @@ export const providers = {
       },
     },
   }),
+  qwen: provider({
+    displayName: "Qwen",
+    envVars: ["QWEN_API_KEY", "DASHSCOPE_API_KEY", "LLM_API_KEY"],
+    models: {
+      "qwen-coder": {
+        displayName: "Qwen Coder",
+        resolve: "qwen/qwen3-coder-plus",
+        openRouterResolve: "openrouter/qwen/qwen3-coder-plus",
+        preferred: true,
+      },
+      "qwen-plus": {
+        displayName: "Qwen Plus",
+        resolve: "qwen/qwen-plus",
+        openRouterResolve: "openrouter/qwen/qwen-plus",
+      },
+      "qwen-max": {
+        displayName: "Qwen Max",
+        resolve: "qwen/qwen-max",
+        openRouterResolve: "openrouter/qwen/qwen3-max",
+      },
+    },
+  }),
   opencode: provider({
     displayName: "OpenCode",
     envVars: ["OPENCODE_API_KEY"],

--- a/models.ts
+++ b/models.ts
@@ -51,6 +51,10 @@ export interface ModelAlias {
    * resolution — for that use `fallback`. used for internal-only tier targets
    * (e.g. gpt-5.4 as a subagent target without exposing it to users). */
   hidden: boolean;
+  /** custom OpenAI-compatible BYOK provider whose `resolve` prefix has no
+   * models.dev entry (the provider is injected into OPENCODE_CONFIG_CONTENT at
+   * run time). skipped by the models.dev existence/deprecation drift checks. */
+  byok: boolean;
 }
 
 interface ModelDef {
@@ -71,6 +75,8 @@ interface ModelDef {
   subagentModel?: string;
   /** hide from selectable lists. does NOT affect resolution; for that use `fallback`. */
   hidden?: boolean;
+  /** custom OpenAI-compatible BYOK provider with no models.dev entry; skips drift checks. */
+  byok?: boolean;
 }
 
 export interface ProviderConfig {
@@ -282,16 +288,19 @@ export const providers = {
         resolve: "qwen/qwen3-coder-plus",
         openRouterResolve: "openrouter/qwen/qwen3-coder-plus",
         preferred: true,
+        byok: true,
       },
       "qwen-plus": {
         displayName: "Qwen Plus",
         resolve: "qwen/qwen-plus",
         openRouterResolve: "openrouter/qwen/qwen-plus",
+        byok: true,
       },
       "qwen-max": {
         displayName: "Qwen Max",
         resolve: "qwen/qwen-max",
         openRouterResolve: "openrouter/qwen/qwen3-max",
+        byok: true,
       },
     },
   }),
@@ -623,6 +632,7 @@ export const modelAliases: ModelAlias[] = Object.entries(providers).flatMap(
       // directly without re-deriving the provider.
       subagentModel: def.subagentModel ? `${providerKey}/${def.subagentModel}` : undefined,
       hidden: def.hidden ?? false,
+      byok: def.byok ?? false,
     }))
 );
 

--- a/models.ts
+++ b/models.ts
@@ -51,9 +51,7 @@ export interface ModelAlias {
    * resolution — for that use `fallback`. used for internal-only tier targets
    * (e.g. gpt-5.4 as a subagent target without exposing it to users). */
   hidden: boolean;
-  /** custom OpenAI-compatible BYOK provider whose `resolve` prefix has no
-   * models.dev entry (the provider is injected into OPENCODE_CONFIG_CONTENT at
-   * run time). skipped by the models.dev existence/deprecation drift checks. */
+  /** custom OpenAI-compatible BYOK provider with no models.dev entry — skips drift/CI-secret checks */
   byok: boolean;
 }
 
@@ -75,7 +73,7 @@ interface ModelDef {
   subagentModel?: string;
   /** hide from selectable lists. does NOT affect resolution; for that use `fallback`. */
   hidden?: boolean;
-  /** custom OpenAI-compatible BYOK provider with no models.dev entry; skips drift checks. */
+  /** custom OpenAI-compatible BYOK provider with no models.dev entry; skips drift checks */
   byok?: boolean;
 }
 
@@ -281,9 +279,7 @@ export const providers = {
   }),
   qwen: provider({
     displayName: "Qwen",
-    // checked in precedence order. LLM_API_KEY is a deliberately generic
-    // OpenAI-compatible fallback (last), so a dedicated QWEN_API_KEY /
-    // DASHSCOPE_API_KEY always wins over it.
+    // precedence order; LLM_API_KEY is the generic OpenAI-compatible fallback (last)
     envVars: ["QWEN_API_KEY", "DASHSCOPE_API_KEY", "LLM_API_KEY"],
     models: {
       "qwen-coder": {

--- a/test/ci.test.ts
+++ b/test/ci.test.ts
@@ -58,11 +58,17 @@ const agnosticTests = getTestNamesFromDir("agnostic");
 const adhocTests = getTestNamesFromDir("adhoc");
 
 // all provider API key names + managed credentials (e.g. Codex auth blob)
-// + GITHUB_TOKEN + model overrides
+// + GITHUB_TOKEN + model overrides. byok-only providers (e.g. qwen) are
+// excluded: Pullfrog holds no managed key for them — the key is user-supplied
+// at run time — so there's nothing to wire into the CI env blocks.
+const isByokOnlyProvider = (p: (typeof providers)[keyof typeof providers]) =>
+  Object.values(p.models).every((m) => m.byok);
 const expectedAgentEnvVars = [
   "GITHUB_TOKEN",
   ...new Set(
-    Object.values(providers).flatMap((p) => [...p.envVars, ...(p.managedCredentials ?? [])])
+    Object.values(providers)
+      .filter((p) => !isByokOnlyProvider(p))
+      .flatMap((p) => [...p.envVars, ...(p.managedCredentials ?? [])])
   ),
   "PULLFROG_MODEL",
 ].sort();

--- a/test/ci.test.ts
+++ b/test/ci.test.ts
@@ -58,9 +58,8 @@ const agnosticTests = getTestNamesFromDir("agnostic");
 const adhocTests = getTestNamesFromDir("adhoc");
 
 // all provider API key names + managed credentials (e.g. Codex auth blob)
-// + GITHUB_TOKEN + model overrides. byok-only providers (e.g. qwen) are
-// excluded: Pullfrog holds no managed key for them — the key is user-supplied
-// at run time — so there's nothing to wire into the CI env blocks.
+// + GITHUB_TOKEN + model overrides. byok-only providers (e.g. qwen) are excluded:
+// Pullfrog holds no managed key for them, so there's nothing in the CI env blocks.
 const isByokOnlyProvider = (p: (typeof providers)[keyof typeof providers]) =>
   Object.values(p.models).every((m) => m.byok);
 const expectedAgentEnvVars = [

--- a/test/models-catalog.main.test.ts
+++ b/test/models-catalog.main.test.ts
@@ -56,6 +56,12 @@ describe("models.dev validity", async () => {
     // is validated separately by the Zen served-list test below.
     if (alias.fallback) continue;
 
+    // byok aliases are custom OpenAI-compatible providers (e.g. qwen → DashScope)
+    // whose `resolve` prefix has no models.dev entry; the provider is injected
+    // into OPENCODE_CONFIG_CONTENT at run time, so there's nothing to validate
+    // upstream. their openRouterResolve, when set, is still checked below.
+    if (alias.byok) continue;
+
     const parsed = parseResolve(alias.resolve);
 
     it(`${alias.resolve} exists on models.dev`, () => {

--- a/test/models-catalog.main.test.ts
+++ b/test/models-catalog.main.test.ts
@@ -56,9 +56,7 @@ describe("models.dev validity", async () => {
     // is validated separately by the Zen served-list test below.
     if (alias.fallback) continue;
 
-    // byok aliases are custom OpenAI-compatible providers (e.g. qwen → DashScope)
-    // whose `resolve` prefix has no models.dev entry; the provider is injected
-    // into OPENCODE_CONFIG_CONTENT at run time, so there's nothing to validate
+    // byok providers (e.g. qwen) have no models.dev entry; nothing to validate
     // upstream. their openRouterResolve, when set, is still checked below.
     if (alias.byok) continue;
 

--- a/utils/apiKeys.test.ts
+++ b/utils/apiKeys.test.ts
@@ -60,6 +60,19 @@ describe("validateAgentApiKey — opencode", () => {
     ).toThrow("no API key found");
   });
 
+  it("passes for qwen when a compatible key is set", () => {
+    process.env.QWEN_API_KEY = "qwen-test";
+    expect(() =>
+      validateAgentApiKey({
+        agent: opencode,
+        model: "qwen/qwen3-coder-plus",
+        authorized: new Set(),
+        owner,
+        name,
+      })
+    ).not.toThrow();
+  });
+
   it("passes the auto-select path when the authorized set is non-empty", () => {
     expect(() =>
       validateAgentApiKey({

--- a/utils/apiKeys.ts
+++ b/utils/apiKeys.ts
@@ -164,6 +164,8 @@ export function validateAgentApiKey(params: {
     }
 
     if (params.agent.name === "opencode") {
+      const envVars = getModelEnvVars(params.model);
+      if (envVars.includes("QWEN_API_KEY") && envVars.some((name) => hasEnvVar(name))) return;
       if (params.authorized.has(params.model)) return;
       throw new Error(
         buildMissingApiKeyError({ owner: params.owner, name: params.name, model: params.model })


### PR DESCRIPTION
Adds first-class Qwen support so coding/review runs can target an OpenAI-compatible Qwen endpoint (Alibaba DashScope, or any compatible gateway) with a bring-your-own key. Right now theres no Alibaba/Qwen entry in the catalog, and a Qwen provider injected from the workflow doesnt survive because the action rebuilds `OPENCODE_CONFIG_CONTENT` internally, so this has to live in the action itself.

Whats here:

`models.ts`: a qwen provider with three aliases. `qwen-coder` (resolves to `qwen3-coder-plus`, marked preferred), `qwen-plus`, `qwen-max`. Each one maps to its OpenRouter equivalent so the openRouterResolve completeness test stays green.

`agents/opencode.ts` and `agents/opencode_v2.ts`: materialize the qwen provider inside the action-owned `OPENCODE_CONFIG_CONTENT` via `@ai-sdk/openai-compatible`. Key and baseURL come from `QWEN_API_KEY`/`QWEN_BASE_URL`, then `DASHSCOPE_*`, then `LLM_*` as a generic OpenAI-compatible fallback, with the DashScope international base URL as the default.

`utils/apiKeys.ts`: accept any of the recognized Qwen env vars during opencode key validation, since that runs before the custom provider config exists.

Plus tests for the model resolution and the key validation.

I verified `qwen3-coder-plus`, `qwen-plus` and `qwen3-coder-next` all respond on the DashScope OpenAI-compatible endpoint. typecheck passes and the full suite is green except one unrelated pre-existing failure in `test/ci.test.ts` that also fails on a clean main, so its not from this change.

One open question for you: do you prefer `DASHSCOPE_API_KEY` as the primary env name over `QWEN_API_KEY`? happy to reorder the fallback chain if so :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-run API key validation and OpenCode provider config for a new external endpoint; scope is additive but affects how runs authenticate before the custom provider exists.
> 
> **Overview**
> Adds **first-class Qwen** support so review/coding runs can target DashScope (or any OpenAI-compatible gateway) with a user-supplied key, instead of relying on workflow-injected config that gets overwritten when the action rebuilds `OPENCODE_CONFIG_CONTENT`.
> 
> The **model catalog** gains a `qwen` provider (`qwen-coder`, `qwen-plus`, `qwen-max`) with a new **`byok` flag** so these aliases skip models.dev drift checks and are omitted from CI workflow env expectations (no managed Pullfrog key). **Both OpenCode harnesses** (`opencode.ts` / `opencode_v2.ts`) now embed `qwenProviderConfig()`—`@ai-sdk/openai-compatible` with models from the registry and credentials from `QWEN_*` → `DASHSCOPE_*` → `LLM_*`, defaulting to the international DashScope compatible base URL.
> 
> **Pre-run validation** accepts any of the Qwen-related env vars for opencode even when the model is not in the `opencode models` authorized set. Tests cover resolution, env vars, API key validation, catalog skips, and CI env filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42fc80f0f819b5f22a842d35fb48c094d590741c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->